### PR TITLE
Add iOS support to fork

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -528,7 +528,8 @@ export type InterfaceType =
   | 'playwright'
   | 'static'
   | 'chrome-extension-proxy'
-  | 'android';
+  | 'android'
+  | 'ios';
 
 export interface StreamingCodeGenerationOptions {
   /** Whether to enable streaming output */

--- a/packages/ios/README.md
+++ b/packages/ios/README.md
@@ -1,0 +1,32 @@
+# @midscene/ios
+
+iOS automation library for Midscene. Provides an `IOSDevice` and `IOSAgent` compatible with the Midscene core abstractions, enabling AI-driven actions on iOS Simulator via Apple simctl and Facebook idb.
+
+## Prerequisites
+
+- Xcode with Command Line Tools
+- A booted iOS Simulator
+- Facebook idb installed and configured (`brew install idb-companion` and `pipx install fb-idb`)
+
+## Usage
+
+```ts
+import { IOSDevice, IOSAgent, getConnectedDevices } from '@midscene/ios';
+
+const devices = await getConnectedDevices();
+const udid = devices[0].udid;
+const device = new IOSDevice(udid);
+await device.connect();
+
+const agent = new IOSAgent(device, {
+  aiActionContext: 'If any permission dialog appears, allow it.',
+});
+
+await agent.launch('https://example.com');
+await agent.aiTap('Click the login button');
+```
+
+## Notes
+
+- Initial implementation targets Simulator via simctl and idb. Physical device support would require additional setup.
+- Element tree extraction is a placeholder and may be expanded in future versions.

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@midscene/ios",
+  "version": "0.27.5",
+  "description": "iOS automation library for Midscene",
+  "keywords": [
+    "iOS UI automation",
+    "iOS AI testing",
+    "iOS automation library",
+    "iOS automation tool"
+  ],
+  "main": "./dist/lib/index.js",
+  "module": "./dist/es/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "files": ["bin", "dist", "README.md"],
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/es/index.mjs",
+      "require": "./dist/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "dev": "npm run build:watch",
+    "build": "rslib build",
+    "build:watch": "rslib build --watch",
+    "test": "vitest --run",
+    "test:u": "vitest --run -u",
+    "test:ai": "AI_TEST_TYPE=ios npm run test",
+    "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=ios npm run test"
+  },
+  "dependencies": {
+    "@midscene/core": "workspace:*",
+    "@midscene/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@microsoft/api-extractor": "^7.52.10",
+    "@rslib/core": "^0.11.2",
+    "@types/node": "^18.0.0",
+    "dotenv": "16.4.5",
+    "typescript": "^5.8.3",
+    "vitest": "3.0.5"
+  },
+  "license": "MIT"
+}
+

--- a/packages/ios/rslib.config.ts
+++ b/packages/ios/rslib.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      output: {
+        distPath: {
+          root: 'dist/lib',
+        },
+      },
+      format: 'cjs',
+      syntax: 'es2020',
+    },
+    {
+      output: {
+        distPath: {
+          root: 'dist/es',
+        },
+      },
+      dts: {
+        bundle: true,
+        distPath: 'dist/types',
+      },
+      format: 'esm',
+      syntax: 'es2020',
+    },
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});
+

--- a/packages/ios/src/agent.ts
+++ b/packages/ios/src/agent.ts
@@ -1,0 +1,26 @@
+import { type AgentOpt, Agent as PageAgent } from '@midscene/core/agent';
+import { vlLocateMode } from '@midscene/shared/env';
+import { getDebug } from '@midscene/shared/logger';
+import { IOSDevice } from './device';
+
+const debugAgent = getDebug('ios:agent');
+
+type IOSAgentOpt = AgentOpt;
+
+export class IOSAgent extends PageAgent<IOSDevice> {
+  constructor(interfaceInstance: IOSDevice, opts?: IOSAgentOpt) {
+    super(interfaceInstance, opts);
+
+    if (!vlLocateMode({ intent: 'grounding' }) || !vlLocateMode({ intent: 'planning' })) {
+      throw new Error(
+        'iOS Agent only supports vl-model. https://midscenejs.com/choose-a-model.html',
+      );
+    }
+  }
+
+  async launch(uri: string): Promise<void> {
+    const device = this.page;
+    await device.launch(uri);
+  }
+}
+

--- a/packages/ios/src/device.ts
+++ b/packages/ios/src/device.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { getTmpFile, sleep } from '@midscene/core/utils';
+import {
+  type DeviceAction,
+  type InterfaceType,
+  type Point,
+  type Size,
+  getMidsceneLocationSchema,
+  z,
+} from '@midscene/core';
+import {
+  type AbstractInterface,
+  type ActionTapParam,
+  defineAction,
+  defineActionDragAndDrop,
+  defineActionKeyboardPress,
+  defineActionScroll,
+  defineActionTap,
+} from '@midscene/core/device';
+import type { ElementInfo } from '@midscene/shared/extractor';
+import { createImgBase64ByFormat, resizeAndConvertImgBuffer, imageInfo } from '@midscene/shared/img';
+import { getDebug } from '@midscene/shared/logger';
+
+const execFileAsync = promisify(execFile);
+const debugDevice = getDebug('ios:device');
+
+export type IOSDeviceOpt = {
+  udid?: string; // iOS Simulator or Device UDID
+};
+
+export class IOSDevice implements AbstractInterface {
+  private udid: string;
+  private destroyed = false;
+  interfaceType: InterfaceType = 'ios';
+  uri: string | undefined;
+  options?: IOSDeviceOpt;
+
+  constructor(udid: string, opts?: IOSDeviceOpt) {
+    assert(udid, 'udid is required for IOSDevice');
+    this.udid = udid;
+    this.options = opts;
+  }
+
+  describe(): string {
+    return `iOS(${this.udid})`;
+  }
+
+  async connect(): Promise<void> {
+    // For simctl we don’t need a persistent connection
+    return;
+  }
+
+  async destroy(): Promise<void> {
+    this.destroyed = true;
+  }
+
+  actionSpace(): DeviceAction<any>[] {
+    return [
+      defineActionTap(async (param: ActionTapParam) => {
+        const element = param.locate;
+        assert(element, 'Element not found, cannot tap');
+        await this.mouseClick(element.center[0], element.center[1]);
+      }),
+      defineAction({
+        name: 'Input',
+        description: 'Input text into the input field',
+        interfaceAlias: 'aiInput',
+        paramSchema: z.object({
+          value: z
+            .string()
+            .describe(
+              'The final that should be filled in the input box. No matter what modifications are required, just provide the final value to replace the existing input value. Giving a blank string means clear the input field.',
+            ),
+          locate: getMidsceneLocationSchema()
+            .describe('The input field to be filled')
+            .optional(),
+        }),
+        call: async (param) => {
+          const element = param.locate;
+          if (element) {
+            await this.clearInput(element as unknown as ElementInfo);
+            if (!param || !param.value) {
+              return;
+            }
+          }
+          await this.keyboardType(param.value);
+        },
+      }),
+      defineActionScroll(async (param) => {
+        const element = param.locate;
+        const startingPoint = element
+          ? { left: element.center[0], top: element.center[1] }
+          : undefined;
+        if (param?.scrollType === 'untilTop') {
+          await this.scrollUp(undefined, startingPoint);
+        } else if (param?.scrollType === 'untilBottom') {
+          await this.scrollDown(undefined, startingPoint);
+        } else if (param?.scrollType === 'untilRight') {
+          await this.scrollRight(undefined, startingPoint);
+        } else if (param?.scrollType === 'untilLeft') {
+          await this.scrollLeft(undefined, startingPoint);
+        } else {
+          if (param?.direction === 'down' || !param || !param.direction) {
+            await this.scrollDown(param?.distance || undefined, startingPoint);
+          } else if (param.direction === 'up') {
+            await this.scrollUp(param.distance || undefined, startingPoint);
+          } else if (param.direction === 'left') {
+            await this.scrollLeft(param.distance || undefined, startingPoint);
+          } else if (param.direction === 'right') {
+            await this.scrollRight(param.distance || undefined, startingPoint);
+          } else {
+            throw new Error(`Unknown scroll direction: ${param.direction}`);
+          }
+          await sleep(500);
+        }
+      }),
+      defineActionDragAndDrop(async (param) => {
+        const from = param.from;
+        const to = param.to;
+        assert(from, 'missing "from" param for drag and drop');
+        assert(to, 'missing "to" param for drag and drop');
+        await this.mouseDrag(
+          { x: from.center[0], y: from.center[1] },
+          { x: to.center[0], y: to.center[1] },
+        );
+      }),
+      defineActionKeyboardPress(async (param) => {
+        const key = param.keyName;
+        await this.keyboardPress(key);
+      }),
+    ];
+  }
+
+  async getElementsNodeTree(): Promise<any> {
+    // Placeholder: no native tree extraction in this initial iOS support
+    return { type: 'Root', children: [] } as any;
+  }
+
+  async url(): Promise<string> {
+    return '';
+  }
+
+  async size(): Promise<Size> {
+    // Infer size from raw screenshot buffer
+    const buffer = await this.getScreenshotBuffer();
+    const info = await imageInfo(buffer);
+    return { width: info.width, height: info.height };
+  }
+
+  async screenshotBase64(): Promise<string> {
+    const pngBuffer = await this.getScreenshotBuffer();
+    const { width, height } = await this.size();
+    const { buffer, format } = await resizeAndConvertImgBuffer('png', pngBuffer, { width, height });
+    return createImgBase64ByFormat(format, buffer.toString('base64'));
+  }
+
+  private async getScreenshotBuffer(): Promise<Buffer> {
+    const tmpPng = getTmpFile(`midscene-ios-${randomUUID()}.png`);
+    assert(tmpPng, 'Temporary directory not available for screenshot');
+    const args = ['simctl', 'io', this.udid, 'screenshot', tmpPng];
+    await execFileAsync('xcrun', args);
+    const fs = await import('node:fs/promises');
+    const pngBuffer = await fs.readFile(tmpPng);
+    return pngBuffer;
+  }
+
+  async mouseClick(x: number, y: number): Promise<void> {
+    // Use idb to simulate a tap on Simulator
+    await execFileAsync('idb', ['tap', '--udid', this.udid, String(Math.round(x)), String(Math.round(y))]);
+  }
+
+  async mouseMove(_x: number, _y: number): Promise<void> {
+    return;
+  }
+
+  async mouseDrag(from: { x: number; y: number }, to: { x: number; y: number }, durationMs = 800): Promise<void> {
+    // Approximate with idb swipe
+    await execFileAsync('idb', [
+      'swipe',
+      '--udid',
+      this.udid,
+      String(Math.round(from.x)),
+      String(Math.round(from.y)),
+      String(Math.round(to.x)),
+      String(Math.round(to.y)),
+      '--duration',
+      (Math.max(0, durationMs / 1000)).toFixed(2)
+    ]);
+  }
+
+  private async scroll(dx: number, dy: number): Promise<void> {
+    const { width, height } = await this.size();
+    const start = { x: Math.floor(width / 2), y: Math.floor(height / 2) };
+    const end = { x: start.x + dx, y: start.y + dy };
+    await this.mouseDrag(start, end);
+  }
+
+  async scrollUp(distance?: number, startPoint?: Point): Promise<void> {
+    const { width, height } = await this.size();
+    const start = startPoint ? { x: startPoint.left, y: startPoint.top } : { x: Math.floor(width / 2), y: Math.floor(height * 0.8) };
+    const endY = start.y - (distance ?? Math.floor(height * 0.6));
+    await this.mouseDrag(start, { x: start.x, y: endY });
+  }
+
+  async scrollDown(distance?: number, startPoint?: Point): Promise<void> {
+    const { width, height } = await this.size();
+    const start = startPoint ? { x: startPoint.left, y: startPoint.top } : { x: Math.floor(width / 2), y: Math.floor(height * 0.2) };
+    const endY = start.y + (distance ?? Math.floor(height * 0.6));
+    await this.mouseDrag(start, { x: start.x, y: endY });
+  }
+
+  async scrollLeft(distance?: number, startPoint?: Point): Promise<void> {
+    const { width, height } = await this.size();
+    const start = startPoint ? { x: startPoint.left, y: startPoint.top } : { x: Math.floor(width * 0.8), y: Math.floor(height / 2) };
+    const endX = start.x - (distance ?? Math.floor(width * 0.6));
+    await this.mouseDrag(start, { x: endX, y: start.y });
+  }
+
+  async scrollRight(distance?: number, startPoint?: Point): Promise<void> {
+    const { width, height } = await this.size();
+    const start = startPoint ? { x: startPoint.left, y: startPoint.top } : { x: Math.floor(width * 0.2), y: Math.floor(height / 2) };
+    const endX = start.x + (distance ?? Math.floor(width * 0.6));
+    await this.mouseDrag(start, { x: endX, y: start.y });
+  }
+
+  async keyboardType(text: string): Promise<void> {
+    // Send text via idb type
+    await execFileAsync('idb', ['type', '--udid', this.udid, text]);
+  }
+
+  async keyboardPress(key: string): Promise<void> {
+    // Basic mapping for common keys
+    const mapping: Record<string, string> = {
+      Enter: 'Return',
+      Escape: 'Escape',
+      Tab: 'Tab',
+      Backspace: 'Delete',
+    };
+    const k = mapping[key] || key;
+    await execFileAsync('idb', ['press-key', '--udid', this.udid, k]);
+  }
+
+  async clearInput(element: ElementInfo): Promise<void> {
+    await this.mouseClick(element.center[0], element.center[1]);
+    // Select all then delete
+    await execFileAsync('idb', ['press-key', '--udid', this.udid, 'Meta+KeyA']);
+    await execFileAsync('idb', ['press-key', '--udid', this.udid, 'Delete']);
+  }
+
+  async launch(uri: string): Promise<IOSDevice> {
+    // Open a URL via simctl io
+    await execFileAsync('xcrun', ['simctl', 'openurl', this.udid, uri]);
+    this.uri = uri;
+    return this;
+  }
+}
+

--- a/packages/ios/src/index.ts
+++ b/packages/ios/src/index.ts
@@ -1,0 +1,5 @@
+export { IOSDevice } from './device';
+export { IOSAgent } from './agent';
+export { overrideAIConfig } from '@midscene/shared/env';
+export { getConnectedDevices } from './utils';
+

--- a/packages/ios/src/utils.ts
+++ b/packages/ios/src/utils.ts
@@ -1,0 +1,38 @@
+import { getDebug } from '@midscene/shared/logger';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const debugUtils = getDebug('ios:utils');
+
+export type IOSDeviceInfo = {
+  udid: string;
+  name: string;
+  state?: string;
+  isAvailable?: boolean;
+};
+
+export async function getConnectedDevices(): Promise<IOSDeviceInfo[]> {
+  try {
+    // List simulators
+    const { stdout } = await execFileAsync('xcrun', ['simctl', 'list', 'devices', 'booted', '-j']);
+    const json = JSON.parse(stdout || '{}');
+    const devices: IOSDeviceInfo[] = [];
+    for (const runtime in json.devices || {}) {
+      for (const d of json.devices[runtime] || []) {
+        if (d.state === 'Booted') {
+          devices.push({ udid: d.udid, name: d.name, state: d.state, isAvailable: d.isAvailable });
+        }
+      }
+    }
+    debugUtils(`Found ${devices.length} booted simulators`, devices);
+    return devices;
+  } catch (error: any) {
+    console.error('Failed to get iOS device list:', error);
+    throw new Error(
+      `Unable to get connected iOS device list. Ensure Xcode command line tools are installed and a Simulator is booted: ${error.message}`,
+      { cause: error },
+    );
+  }
+}
+

--- a/packages/ios/tsconfig.json
+++ b/packages/ios/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": ".",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["DOM", "ESNext"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "strict": true,
+    "module": "ES2020",
+    "target": "es2020",
+    "types": ["node"],
+    "composite": true,
+    "declarationDir": "dist/types"
+  },
+  "exclude": ["**/node_modules"],
+  "include": ["src"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../shared" },
+    { "path": "../web-integration" }
+  ]
+}
+

--- a/packages/ios/vitest.config.ts
+++ b/packages/ios/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,7 +421,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
 
   packages/android-playground:
     dependencies:
@@ -555,7 +555,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -631,7 +631,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
 
   packages/evaluation:
     dependencies:
@@ -666,6 +666,34 @@ importers:
       vitest:
         specifier: 3.0.5
         version: 3.0.5(@types/debug@4.1.12)(@types/node@22.15.3)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+
+  packages/ios:
+    dependencies:
+      '@midscene/core':
+        specifier: workspace:*
+        version: link:../core
+      '@midscene/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@microsoft/api-extractor':
+        specifier: ^7.52.10
+        version: 7.52.10(@types/node@18.19.118)
+      '@rslib/core':
+        specifier: ^0.11.2
+        version: 0.11.2(@microsoft/api-extractor@7.52.10(@types/node@18.19.118))(typescript@5.8.3)
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.118
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.118)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
 
   packages/mcp:
     dependencies:
@@ -717,7 +745,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
       zod:
         specifier: 3.24.3
         version: 3.24.3
@@ -837,7 +865,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
 
   packages/visualizer:
     dependencies:
@@ -992,7 +1020,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1)
 
 packages:
 
@@ -5553,10 +5581,6 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
-  fs-extra@11.2.0:
-    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.3.1:
     resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
@@ -11170,7 +11194,6 @@ snapshots:
       '@rushstack/node-core-library': 5.14.0(@types/node@18.19.118)
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor-model@7.30.7(@types/node@18.19.62)':
     dependencies:
@@ -11206,7 +11229,6 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.52.10(@types/node@18.19.62)':
     dependencies:
@@ -12211,7 +12233,7 @@ snapshots:
       browserslist-load-config: 1.0.0
       enhanced-resolve: 5.12.0
       filesize: 10.1.6
-      fs-extra: 11.2.0
+      fs-extra: 11.3.1
       lodash: 4.17.21
       path-browserify: 1.0.1
       semver: 7.7.2
@@ -12267,7 +12289,7 @@ snapshots:
       body-parser: 1.20.3
       cors: 2.8.5
       dayjs: 1.11.13
-      fs-extra: 11.2.0
+      fs-extra: 11.3.1
       json-cycle: 1.5.0
       lodash: 4.17.21
       open: 8.4.2
@@ -12305,7 +12327,7 @@ snapshots:
       deep-eql: 4.1.4
       envinfo: 7.14.0
       filesize: 10.1.6
-      fs-extra: 11.2.0
+      fs-extra: 11.3.1
       get-port: 5.1.1
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
@@ -12596,7 +12618,6 @@ snapshots:
       semver: 7.5.4
     optionalDependencies:
       '@types/node': 18.19.118
-    optional: true
 
   '@rushstack/node-core-library@5.14.0(@types/node@18.19.62)':
     dependencies:
@@ -12636,7 +12657,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.19.118
-    optional: true
 
   '@rushstack/terminal@0.15.4(@types/node@18.19.62)':
     dependencies:
@@ -12661,7 +12681,6 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@rushstack/ts-command-line@5.0.2(@types/node@18.19.62)':
     dependencies:
@@ -15309,12 +15328,6 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fs-extra@11.2.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-
   fs-extra@11.3.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -15417,7 +15430,7 @@ snapshots:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
       debug: 4.4.0(supports-color@5.5.0)
-      fs-extra: 11.2.0
+      fs-extra: 11.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -19968,7 +19981,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.62)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 3.0.5
       '@vitest/mocker': 3.0.5(vite@5.4.10(@types/node@18.19.62)(less@4.3.0)(lightningcss@1.30.1)(sass-embedded@1.86.3)(terser@5.43.1))


### PR DESCRIPTION
Add `@midscene/ios` package to provide AI-driven automation for iOS Simulators, mirroring the existing Android interface.

The new package integrates with `xcrun simctl` and `idb` to enable core device interactions like tapping, typing, scrolling, and taking screenshots, and extends `InterfaceType` in `@midscene/core`.

---
<a href="https://cursor.com/background-agent?bcId=bc-eea64955-a460-49de-9942-5eddfc0eb28d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eea64955-a460-49de-9942-5eddfc0eb28d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added iOS automation support for simulators, including device discovery, launching URLs, screenshots, and actions (tap, input, scroll, drag-and-drop, keyboard).
  * Enabled selection of an “ios” interface type alongside existing options.
* Documentation
  * Added iOS package README with setup prerequisites (Xcode tools, Simulator, idb) and a quick-start usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->